### PR TITLE
54 bug in mexpv when called already at steady state

### DIFF
--- a/src/+ssit/+fsp_ode_solvers/mexpv_modified_2.m
+++ b/src/+ssit/+fsp_ode_solvers/mexpv_modified_2.m
@@ -280,6 +280,7 @@ while tNow < t_out && i_prt<=length(Time_array)
     % end
     if sum(abs((Ain*w)))<(btol/(max(Time_array)-min(Time_array)))
         % Detect SS and quit early
+        err_loc = btol;
         t_step = min([Time_array(i_prt)-tNow,nextFixedTime-tNow]);
     else
 

--- a/tests/poissonTest.m
+++ b/tests/poissonTest.m
@@ -749,5 +749,19 @@ classdef poissonTest < matlab.unittest.TestCase
                 'Datafield led to incorrec totals.');
             
         end
-    end
+
+
+        function TestModelAlreadyAtSteadyState(testCase)
+            % Set all parameters to zero. This will ensure that the model
+            % is at steady state, since no reactions will ever fire, and
+            % thus the distribution of the system's states will be unable
+            % to change.
+
+            paramValues = testCase.Poiss.parameters(:, 2);
+            numParams = length(paramValues);
+            newParamValues = num2cell(zeros(numParams, 1));
+            testCase.Poiss.parameters(:, 2) = newParamValues;
+            testCase.Poiss.solve;            
+        end % TestModelAlreadyAtSteadyState
+    end % Tests
 end


### PR DESCRIPTION
@Munsky,

_Per_ best practices of TDD, I first added a minimal test case, `TestModelAlreadyAtSteadyState`, that reproduces the bug. It failed on my machine before the fix and then passed with the fix.

All tests are passing on GitHub on the latest MATLAB on both OSes. See PR #53 for why some tests will now fail on earlier versions on MATLAB.

I think this is ready to reintegrate. 